### PR TITLE
Fix VAGRANTFILE_API_VERSION check

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-if not VAGRANTFILE_API_VERSION
+if not defined? VAGRANTFILE_API_VERSION
   VAGRANTFILE_API_VERSION = "2"
 end
 


### PR DESCRIPTION
Without using "defined" function, this will check if the value of VAGRANTFILE_API_VERSION is True or False, but VAGRANTFILE_API_VERSION may not be defined (for example, if the user didn't set this value in his ~/.vagrant.d/Vagrantfile), giving a "unitialized constant" error.
