### PR TITLE
Use KVM paravirtualization

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,6 +54,9 @@ def configure_vm(name, vm, conf)
     if conf["mac_address_#{name}"]
       vb.customize ["modifyvm", :id, "--macaddress2", conf["mac_address_#{name}"]]
     end
+    # Example of how to use KVM paravirtualization in VirtualBox 5.0
+    # See https://github.com/mitchellh/vagrant/pull/5929
+    vb.customize ["modifyvm", :id, "--paravirtprovider", "kvm"]
   end
 
   # puppet provisioning


### PR DESCRIPTION
This is an example of how the KVM paravirtualization provider in VirtualBox 5.0 could be supported, once it's merged into upstream Vagrant.

The PR in Vagrant is at:

https://github.com/mitchellh/vagrant/pull/5929