### PR TITLE
Add manager_extra_services to config.yaml and local.erb

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,14 @@ in ``config.yaml.sample``.
 Default security group with ssh and ping opened up.
 
 Installation of the stack user ssh key as the default keypair.
+
+Enable additional services
+------------------------
+The devstack environment created by this `Vagrantfile` includes just the basic
+services to get started with OpenStack. If you want to try more services, you
+can enable them on the manager node through the ``config.yaml`` file.
+
+For example if you want to enable [Swift](http://swift.openstack.org), you can
+add the following line to your ``config.yaml``:
+
+    manager_extra_services: s-proxy s-object s-container s-account

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -66,3 +66,8 @@ bridge_int: eth1
 # Extra images to download and add to glance, a list of url's comma separated
 # for new images to be added to glance
 #extra_images: https://cloud-images.ubuntu.com/precise/current/precise-server-cloudimg-amd64-disk1.img,https://cloud-images.ubuntu.com/trusty/current/trusty-server-cloudimg-amd64-disk1.img
+
+# Extra services to enable on the manager node, a space separated list of
+# additional services to enable on the manager node. For example, to enable
+# Swift, just uncomment the next line.
+#manager_extra_services: s-proxy s-object s-container s-account

--- a/puppet/modules/devstack/templates/local.erb
+++ b/puppet/modules/devstack/templates/local.erb
@@ -61,6 +61,12 @@ LDAP_PASSWORD=<%= @service_password %>
 enable_service ldap
 <% end %>
 
+<% if defined?(@manager_extra_services) %>
+# enable extra services
+
+enable_service <%= @manager_extra_services %>
+<% end %>
+
 <% end %>
 
 [[post-config|$NOVA_CONF]]


### PR DESCRIPTION
Following the specification defined [here](http://docs.openstack.org/developer/devstack/stackrc.html), additional services can be enabled in the `localrc` file:

> Other services that are not enabled by default can be enabled in localrc. For example, to add Swift, use the following service names:
>  `enable_service s-proxy s-object s-container s-account`

The `manager_extra_services` key in the `config.yaml` allows the specification of services to be enabled in the manager node. This is useful for example to test *Swift* without having to create another node.

If the `manager_extra_services` key is specified, a new `enable_service` line is added to the manager `localrc` file, with the requested services.