### PR TITLE
Add use_ip_resolver to config.yaml in order to use vagrant-hostmanager's ip_resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ If the used hostnames in the ``config.yaml`` file (variable ``hostname_manager``
 and ``hostname_compute``) are not resolvable you have to install the
 ``vagrant-hostmanager`` plugin (``vagrant plugin install vagrant-hostmanager``).
 
+If the nodes are still not able to communicate to each other even after
+installing the ``vagrant-hostnamanger`` plugin (for example you get errors about
+the compute node not being able to communicate to *cinder c-api* during the
+*vagrant up* phase), set the variable ``use_ip_resolver`` in the ``config.yaml``
+file to ``true``, in order to obtain the correct nodes ip.
+
 
 Local Setup
 --------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -126,7 +126,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.hostmanager.manage_host = true
     config.hostmanager.ignore_private_ip = false
     config.hostmanager.include_offline = true
-    if conf["use_bridge"] == false
+    if conf["use_bridge"] == false || conf["use_ip_resolver"] == true
       config.hostmanager.ip_resolver = proc do |machine|
         result = ""
         begin

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -29,6 +29,12 @@ setup_mode: devstack
 # it exactly right.
 bridge_int: eth1
 
+# Enable the vagrant-hostmanager's ip_resolver in order to get the correct
+# nodes ip. You should install the vagrant-hostmanager plugin and enable this
+# option if the nodes are not able to communicate (for example you get errors
+# during the compute vagrant up phase not being able to communicate to c-api).
+#use_ip_resolver: true
+
 # A non upstream for the base box, used to speed things up. Choose one of
 # box_name (for a locally added box) or box_url for the url of a nearby box.
 #box_name: 'my.favorite'


### PR DESCRIPTION
Add `use_ip_resolver` key to `config.yaml` in order to use *vagrant-hostmanager*'s *ip_resolver* even when `use_bridge` is not `false`.

Even if the *vagrant-hostmanager* plugin is installed, the *ip_resolver*, which sets the correct node ip in the guests' and host's `/etc/hosts`, is enabled only when the key `use_bridge` is explicitly set to `false`.
In an environment where the ip is assigned by a dhcp on the bridged interface, it is important to use the *ip_resolver*, the key `use_ip_resolver` in the `config.yaml` permits this.

*[Actually I think that the ip_resolver should be enabled by default to facilitate new users, but I added the option to be disabled by default in order not to break current working environments.]*