### PR TITLE
Hotfix/keypair add in local sh

### DIFF
--- a/puppet/modules/devstack/files/local.sh
+++ b/puppet/modules/devstack/files/local.sh
@@ -2,15 +2,17 @@
 
 set -o xtrace
 
+openrc=/home/stack/devstack/openrc
+pubkey_file=/home/stack/.ssh/authorized_keys
+
 echo "Running local.sh"
 
-openrc=/home/stack/devstack/openrc
-source $openrc
+source "$openrc"
 
 if is_service_enabled n-api; then
     for user in admin demo; do
-        source $openrc $user $user
-        nova keypair-add --pub-key /home/stack/.ssh/authorized_keys default
+        source "$openrc" "$user" "$user"
+        nova keypair-add --pub-key "$pubkey_file" default
         nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0
         nova secgroup-add-rule default tcp 22 22 0.0.0.0/0
     done

--- a/puppet/modules/devstack/files/local.sh
+++ b/puppet/modules/devstack/files/local.sh
@@ -1,19 +1,27 @@
 #!/bin/bash
 
+echo "Running local.sh"
+
 set -o xtrace
 
 openrc=/home/stack/devstack/openrc
-pubkey_file=/home/stack/.ssh/authorized_keys
-
-echo "Running local.sh"
+authorized_keys_file=/home/stack/.ssh/authorized_keys
 
 source "$openrc"
 
 if is_service_enabled n-api; then
+    # Extract valid public key into tmp file to work around the issue,
+    # introduced by puppet adding comments in the beginning of authorized_keys
+    pubkey_file=`mktemp`
+    grep -vE '^\s*#' "$authorized_keys" | head -n 1 > "$pubkey_file"
+
     for user in admin demo; do
         source "$openrc" "$user" "$user"
         nova keypair-add --pub-key "$pubkey_file" default
         nova secgroup-add-rule default icmp -1 -1 0.0.0.0/0
         nova secgroup-add-rule default tcp 22 22 0.0.0.0/0
     done
+
+    # Tmp file cleanup
+    rm -f "$pubkey_file"
 fi


### PR DESCRIPTION
During my attempts to run this project, hours of googling and debugging I've mentioned, that `nova keypair-add` command failed.
I've troubleshoot this issue and found out, that it fails because `authorized_keys` file contains comments stating it's been created by puppet. Obviously keystone couldn't recognize it's contents as a vaild public key. Perhaps it did work in the past, I'm not sure, but now it doesn't:

```shell
stack@manager:~/.ssh$ openstack keypair create --public-key authorized_keys default
Keypair data is invalid: failed to generate fingerprint (HTTP 400) (Request-ID: req-5b18a7c2-a5e3-48e6-a4c4-a5dab9ed346e)
stack@manager:~/.ssh$ cat authorized_keys
# HEADER: This file was autogenerated at 2016-07-11 12:02:13 +0000
# HEADER: by puppet.  While it can still be managed manually, it
# HEADER: is definitely not recommended.
ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC3vsGZrCRsBywNgVr1ofzTFK7cD2k87mY7LgwTlJea+2LBPPxOjKC5hbvIgcv6QTjvoNsZvqnfhLqj2SbbqbKPlSzOaFAL6JizVhvNnbB8zVKul/wcAfDJJZPi700MhS8YNhS/FkAAqYsN+ar0nfPz5XmEGzvMPqkafnEv2iFxSeqXjEK4lJ7AmcvzBZGkDEIpSRrLuvXliMmowe3T0kwpqEGtqrEtG63YtKoXhGWCCyhsl0TXBLWwVM7aoEJVxikQD9nJYHp5G2qwgWDAPIovm8in9l3iLv+ZHP9Ua4YeqLI+lclpsLqZJXlUsLZtV0Cmnb4Uca6RC3VbVFTphq73 stack
```

After removing those comments during debug, adding the key succeeds. So I'm publishing my fix in this PR. I basically just retrieve the first public key from `authorized_keys`, put it into temporary location, pass this valid file to `nova` command and finally remove it.