### PR TITLE
Update default box to Ubuntu 16.04 (Xenial)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,9 @@ def configure_vm(name, vm, conf)
     end
   end
 
+  # puppet not installed by default in ubuntu-xenial
+  vm.provision "shell", inline: "sudo apt-get install -y puppet"
+
   # puppet provisioning
   vm.provision "puppet" do |puppet|
     puppet.manifests_path = "puppet/manifests"
@@ -106,11 +109,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #
   # The boot time is long for these, so I recommend that you convert to a local
   # version as soon as you can.
-  config.vm.box = conf['box_name'] || 'ubuntu/trusty64'
+  config.vm.box = conf['box_name'] || 'ubuntu/xenial64'
   config.vm.box_url = conf['box_url'] if conf['box_url']
 
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
+    # see https://github.com/fgrehm/vagrant-cachier/issues/175
+    config.cache.synced_folder_opts = {
+      owner: "_apt",
+      group: "ubuntu",
+      mount_options: ["dmode=777", "fmode=666"]
+    }
   end
 
   if Vagrant.has_plugin?("vagrant-proxyconf") && conf['proxy']

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,7 @@ def configure_vm(name, vm, conf)
       "is_compute" => (name != "manager"),
       "use_ldap" => conf["use_ldap"] || false,
       "extra_images" => conf["extra_images"] || "",
+      "vagrant_username" => conf["vagrant_username"] || "ubuntu",
     }
     # add all the rest of the content in the conf file
     conf.each do |k, v|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,8 @@ def configure_vm(name, vm, conf)
       "is_compute" => (name != "manager"),
       "use_ldap" => conf["use_ldap"] || false,
       "extra_images" => conf["extra_images"] || "",
+      "guest_interface_default" => conf["guest_interface_default"] || "enp0s8",
+      "host_ip_iface" => conf["host_ip_iface"] || "enp0s8",
       "vagrant_username" => conf["vagrant_username"] || "ubuntu",
     }
     # add all the rest of the content in the conf file

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -40,6 +40,9 @@ bridge_int: eth1
 #box_name: 'my.favorite'
 #box_url: http://gallifrey/vagrant/devstack-2014-02-19.box
 
+# Vagrant username used in box image, e.g. ubuntu
+#vagrant_username: vagrant
+
 # Non upstream Git URL to fetch Devstack from instead.
 #devstack_git: /home/vagrant/openstack/devstack
 
@@ -68,6 +71,10 @@ bridge_int: eth1
 # will be used.
 #ip_address_manager: 10.0.10.10
 #ip_address_compute: 10.0.10.20
+
+# Name of network interface in virtual machine - e.g. enp0s8 in ubuntu
+#guest_interface_default: eth1
+#host_ip_iface: eth1
 
 # Extra images to download and add to glance, a list of url's comma separated
 # for new images to be added to glance

--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -1,7 +1,9 @@
 node default {
   include base
   include user::stack
-  include user::vagrant
+  class {'user::vagrant':
+    username => $::vagrant_username,
+  }
   include grenade
   include devstack
 }

--- a/puppet/modules/devstack/templates/local.erb
+++ b/puppet/modules/devstack/templates/local.erb
@@ -18,8 +18,8 @@ DATABASE_TYPE=mysql
 
 # networking configuration parameters
 
-GUEST_INTERFACE_DEFAULT=eth1
-HOST_IP_IFACE=eth1
+GUEST_INTERFACE_DEFAULT=<%= @guest_interface_default %>
+HOST_IP_IFACE=<%= @host_ip_iface %>
 
 # logging configuration parameters
 

--- a/puppet/modules/user/manifests/vagrant.pp
+++ b/puppet/modules/user/manifests/vagrant.pp
@@ -5,14 +5,14 @@ class user::vagrant(
   $username = 'vagrant'
 )
 {
-  file {'/home/vagrant/.bashrc':
+  file {"/home/${username}/.bashrc":
     owner => $username,
     group => $username,
     mode => '0644',
     source => 'puppet:///modules/user/stack_bashrc',
   }
 
-  file {'/home/vagrant/devstack':
+  file {"/home/${username}/devstack":
     owner => $username,
     group => $username,
     mode => '0644',
@@ -20,7 +20,7 @@ class user::vagrant(
     target => '/home/stack/devstack',
   }
 
-  file {'/home/vagrant/grenade':
+  file {"/home/${username}/grenade":
     owner => $username,
     group => $username,
     mode => '0644',


### PR DESCRIPTION
[devstack commit 71640bf](https://github.com/openstack-dev/devstack/commit/71640bfe39d6aec8894e05cf4efb52ae06e20eed) (Feb 26, 2017) removed support for Ubuntu 14 (Trusty).

This PR updates the default box to xenial and makes some extra configuration parameters available (vagrant_username, guest_interface_default and host_ip_iface) to continue to allow other distributions to be used.