### PR TITLE
Update APT before installing puppet

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,6 +57,7 @@ def configure_vm(name, vm, conf)
   end
 
   # puppet not installed by default in ubuntu-xenial
+  vm.provision "shell", inline: "sudo apt-get update"
   vm.provision "shell", inline: "sudo apt-get install -y puppet"
 
   # puppet provisioning


### PR DESCRIPTION
Installing puppet would fail in with some base boxes. A simple 'apt-get
update' will fix that situation.